### PR TITLE
Disable xmerl_scan output

### DIFF
--- a/lib/wechat_pay/utils/xml_parser.ex
+++ b/lib/wechat_pay/utils/xml_parser.ex
@@ -26,7 +26,7 @@ defmodule WechatPay.Utils.XMLParser do
       {doc, _} =
         xml_string
         |> :binary.bin_to_list()
-        |> :xmerl_scan.string()
+        |> :xmerl_scan.string(quiet: true)
 
       parsed_xml = extract_doc(doc, root_element)
 


### PR DESCRIPTION
Fix #55

**Debug**
Use `mix test --trace` to find the test having the output.

**Reference**
https://www.erlang.org/doc/man/xmerl_scan.html
> {quiet, Flag} Set to 'true' if xmerl should behave quietly and not output any information to standard output (default 'false').

