### PR TITLE
Improve crypto compatibility with OTP >= 23

### DIFF
--- a/lib/wechat_pay/plug/refund.ex
+++ b/lib/wechat_pay/plug/refund.ex
@@ -121,7 +121,7 @@ defmodule WechatPay.Plug.Refund do
   end
 
   # https://erlang.org/doc/apps/crypto/new_api.html#the-new-api
-  if System.otp_release() |> String.to_integer() >= 23 do
+  if Code.ensure_loaded?(:crypto) && function_exported?(:crypto, :crypto_one_time, 4) do
     defp crypto_block_decrypt(algorithm, key, data) do
       :crypto.crypto_one_time(algorithm, key, data, false)
     end

--- a/lib/wechat_pay/plug/refund.ex
+++ b/lib/wechat_pay/plug/refund.ex
@@ -107,7 +107,7 @@ defmodule WechatPay.Plug.Refund do
       |> Base.decode64()
 
     try do
-      xml_string = crypto_block_decrypt(:aes_256_ecb, key, data)
+      xml_string = crypto_block_decrypt(:aes_ecb, key, data)
       {:ok, xml_string}
     rescue
       ArgumentError ->
@@ -122,14 +122,14 @@ defmodule WechatPay.Plug.Refund do
 
   # https://erlang.org/doc/apps/crypto/new_api.html#the-new-api
   if Code.ensure_loaded?(:crypto) && function_exported?(:crypto, :crypto_one_time, 4) do
-    defp crypto_block_decrypt(algorithm, key, data) do
-      :crypto.crypto_one_time(algorithm, key, data, false)
-    end
-  else
-    defp map_algorithm(:aes_256_ecb), do: :aes_ecb
+    defp map_algorithm(:aes_ecb), do: :aes_256_ecb
 
     defp crypto_block_decrypt(algorithm, key, data) do
-      :crypto.block_decrypt(map_algorithm(algorithm), key, data)
+      :crypto.crypto_one_time(map_algorithm(algorithm), key, data, false)
+    end
+  else
+    defp crypto_block_decrypt(algorithm, key, data) do
+      :crypto.block_decrypt(algorithm, key, data)
     end
   end
 end

--- a/lib/wechat_pay/utils/signature.ex
+++ b/lib/wechat_pay/utils/signature.ex
@@ -41,7 +41,7 @@ defmodule WechatPay.Utils.Signature do
   end
 
   # https://erlang.org/doc/apps/crypto/new_api.html#the-new-api
-  if System.otp_release() |> String.to_integer() >= 23 do
+  if Code.ensure_loaded?(:crypto) && function_exported?(:crypto, :mac, 4) do
     defp crypto_hmac(type, key, data) do
       :crypto.mac(:hmac, type, key, data)
     end

--- a/lib/wechat_pay/utils/signature.ex
+++ b/lib/wechat_pay/utils/signature.ex
@@ -32,12 +32,23 @@ defmodule WechatPay.Utils.Signature do
 
     # :crypto.sign(:rsa, :sha256, sign_string, api_key)
     :sha256
-    |> :crypto.hmac(api_key, sign_string)
+    |> crypto_hmac(api_key, sign_string)
     |> Base.encode16()
   end
 
   def sign(data, api_key, _other) when is_map(data) do
     sign(data, api_key, :md5)
+  end
+
+  # https://erlang.org/doc/apps/crypto/new_api.html#the-new-api
+  if System.otp_release() |> String.to_integer() >= 23 do
+    defp crypto_hmac(type, key, data) do
+      :crypto.mac(:hmac, type, key, data)
+    end
+  else
+    defp crypto_hmac(type, key, data) do
+      :crypto.hmac(type, key, data)
+    end
   end
 
   @doc """


### PR DESCRIPTION
Fix the following warnings:

```
warning: :crypto.hmac/3 is undefined or private, use crypto:mac/4 instead
  lib/wechat_pay/utils/signature.ex:35: WechatPay.Utils.Signature.sign/3

warning: :crypto.block_decrypt/3 is undefined or private, use crypto:crypto_one_time/4 or crypto:crypto_init/3 + crypto:crypto_update/2 + crypto:crypto_final/1 instead
  lib/wechat_pay/plug/refund.ex:114: WechatPay.Plug.Refund.decrypt_data/2
```

Reference: https://erlang.org/doc/apps/crypto/new_api.html#the-new-api